### PR TITLE
feat: Add sprite navigation with ESC/Enter controls in interactive mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap 4.5.47",
+ "crossterm",
  "directories",
  "hex",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,11 @@ thiserror = "2.0"
 # Sprite display dependencies
 viuer = { version = "0.7", optional = true }
 image = { version = "0.24", optional = true }
+crossterm = { version = "0.27", optional = true }
 
 [features]
 default = []
-sprites = ["viuer", "image"]
+sprites = ["viuer", "image", "crossterm"]
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
## Summary
- インタラクティブ選択でスプライト表示後に確定/再選択のナビゲーションを追加
- Enterキーで選択確定、ESCキーで再選択できる機能を実装
- ユーザーが視覚的にポケモンを確認してから最終決定できるように改善

## Changes
- crossterm依存関係を追加（キーボードイベント処理用）
- `InteractiveSelector`にスプライトサービスを統合
- `show_sprite_with_navigation`メソッドを追加
  - スプライト表示後にEnter/ESCのキー入力を待機
  - Enterで選択確定、ESCで再選択画面に戻る

## Test plan
- [ ] `cargo build --features sprites`でビルド成功
- [ ] インタラクティブ選択でポケモンを選択後、スプライトが表示される
- [ ] Enterキーで選択が確定される
- [ ] ESCキーで再選択画面に戻る
- [ ] 既存のテストがすべてパスする

## Related Issues
- #10 - 再帰呼び出しによるスタックオーバーフローの可能性（将来的な改善点）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Interactive selection can show a sprite preview (when the “sprites” feature is enabled). Use Enter to confirm or Esc to return and reselect.
- Chores
  - Expanded the “sprites” feature to include an optional terminal backend dependency for input/preview support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->