### PR TITLE
fix: スプライトが skim の選択UIに重なる問題を修正 (#12)

### DIFF
--- a/scripts/debug/pty-capture.py
+++ b/scripts/debug/pty-capture.py
@@ -35,13 +35,15 @@ def main() -> int:
     if not cmd:
         p.error("コマンドが指定されていません")
 
+    winsz = struct.pack("HHHH", args.rows, args.cols, 0, 0)
+
     pid, fd = pty.fork()
     if pid == 0:
+        # 親が設定するより先に子が走り出すと、skim / viuer が既定のサイズを
+        # 見てしまう。exec の前に子自身の端末へ適用する。
+        fcntl.ioctl(0, termios.TIOCSWINSZ, winsz)
         os.execvp(cmd[0], cmd)
         os._exit(127)
-
-    fcntl.ioctl(fd, termios.TIOCSWINSZ,
-                struct.pack("HHHH", args.rows, args.cols, 0, 0))
 
     chunks: list[bytes] = []
     pending = list(args.send)

--- a/scripts/debug/pty-capture.py
+++ b/scripts/debug/pty-capture.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""指定サイズの pty でコマンドを起動し、端末へ出力された生バイトを記録する。
+
+skim / viuer のようにカーソル制御を直接行うコードは、出力されたエスケープ
+シーケンスを見ないと挙動を確認できないため。
+
+usage: pty-capture.py --rows 30 --cols 100 --out capture.raw \
+           --send $'\\r' --delay 0.6 -- ./target/debug/poke-lookup -s ピカ
+"""
+
+import argparse
+import fcntl
+import os
+import pty
+import select
+import struct
+import sys
+import termios
+import time
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--rows", type=int, default=30)
+    p.add_argument("--cols", type=int, default=100)
+    p.add_argument("--out", required=True)
+    p.add_argument("--send", action="append", default=[],
+                   help="子プロセスへ送るキー入力。複数指定で順に送信")
+    p.add_argument("--delay", type=float, default=0.6,
+                   help="各送信の前に待つ秒数")
+    p.add_argument("cmd", nargs=argparse.REMAINDER)
+    args = p.parse_args()
+
+    cmd = args.cmd[1:] if args.cmd and args.cmd[0] == "--" else args.cmd
+    if not cmd:
+        p.error("コマンドが指定されていません")
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execvp(cmd[0], cmd)
+        os._exit(127)
+
+    fcntl.ioctl(fd, termios.TIOCSWINSZ,
+                struct.pack("HHHH", args.rows, args.cols, 0, 0))
+
+    chunks: list[bytes] = []
+    pending = list(args.send)
+    next_send = time.time() + args.delay
+
+    while True:
+        now = time.time()
+        if pending and now >= next_send:
+            os.write(fd, pending.pop(0).encode())
+            next_send = now + args.delay
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if fd in r:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+        elif not pending and now > next_send + 2.0:
+            break
+
+    os.close(fd)
+    os.waitpid(pid, 0)
+
+    raw = b"".join(chunks)
+    with open(args.out, "wb") as f:
+        f.write(raw)
+    print(f"captured {len(raw)} bytes -> {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -101,6 +101,11 @@ impl InteractiveSelector {
         // skimオプションを設定
         let options = SkimOptionsBuilder::default()
             .height(Some("40%"))
+            // tuikit の終了処理は実行時の状態ではなくこのオプションで分岐する。
+            // false のままだと、インラインモードで代替画面に入っていないのに
+            // quit_alternate_screen だけを出すため、描画が消えずカーソルも戻らず、
+            // 直後のスプライトが選択UIに重なる（issue #12）。
+            .no_clear_start(true)
             .multi(false)
             .preview(Some(""))
             .preview_window(Some("down:3:wrap"))

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -9,10 +9,6 @@ use std::collections::HashMap;
 #[cfg(feature = "sprites")]
 use std::path::{Path, PathBuf};
 
-/// スプライト表示に使う端末の桁数
-#[cfg(feature = "sprites")]
-const SPRITE_WIDTH: u32 = 32;
-
 /// スプライト画像の取得・表示を管理するサービス
 #[cfg(feature = "sprites")]
 pub struct SpriteService {
@@ -134,10 +130,6 @@ impl SpriteService {
             let config = viuer::Config {
                 transparent: true,
                 absolute_offset: false,
-                // width を渡さないと viuer は端末サイズいっぱいに拡大するため、
-                // 96x96 のスプライトが画面をほぼ埋めてしまう。高さは
-                // アスペクト比から算出され、32 桁なら 16 行に収まる。
-                width: Some(SPRITE_WIDTH),
                 ..Default::default()
             };
 

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -9,6 +9,10 @@ use std::collections::HashMap;
 #[cfg(feature = "sprites")]
 use std::path::{Path, PathBuf};
 
+/// スプライト表示に使う端末の桁数
+#[cfg(feature = "sprites")]
+const SPRITE_WIDTH: u32 = 32;
+
 /// スプライト画像の取得・表示を管理するサービス
 #[cfg(feature = "sprites")]
 pub struct SpriteService {
@@ -130,6 +134,10 @@ impl SpriteService {
             let config = viuer::Config {
                 transparent: true,
                 absolute_offset: false,
+                // width を渡さないと viuer は端末サイズいっぱいに拡大するため、
+                // 96x96 のスプライトが画面をほぼ埋めてしまう。高さは
+                // アスペクト比から算出され、32 桁なら 16 行に収まる。
+                width: Some(SPRITE_WIDTH),
                 ..Default::default()
             };
 


### PR DESCRIPTION
Fixes #12

## 変更

skim に `no_clear_start(true)` を渡す（issue の修正案A）。

`height("40%")` により skim はインラインモードで動作し代替画面に入らないが、tuikit の `pause()` は実行時の状態ではなく `disable_alternate_screen` オプションで後始末を分岐する（`tuikit-0.5.0/src/term.rs:722-728`）。既定値 false では、入っていない代替画面から出るだけで描画は消えずカーソルも戻らないため、直後の viuer 描画が選択UIに重なっていた。

再現に使った `scripts/debug/pty-capture.py` も追加した。

## 検証

実際の Ghostty（1.3.1）の中でアプリを動かし、アプリと端末の往復バイトを記録して確認した。

修正前 — `rmcup` の後に消去もカーソル移動も無く、そのまま画像が始まる:
```
\x1b[?1049l\x1b[1C\x1b[1C...
```

修正後 — `rmcup` は出ず、インライン用の後始末が出てから画像が始まる:
```
\x1b[?25h\x1b[2;1H\x1b[J\x1b[1C\x1b[1C...
```

スプライトの描画（半ブロック文字 586個）はこれまでどおり出ている。

`cargo build` / `clippy` / `cargo test`（sprites 有効で42件）はいずれも通過。

## この PR に含めないもの

issue の修正案C（`Config.width` の固定）は入れていない。拡大自体は問題ではないため。

なお調査の過程で、スプライトの描画品質について以下が分かったので別途 issue にする:

- viuer 0.7 の graphics protocol 判定は `TERM` に `"kitty"` を含むかで見ており、Ghostty（`TERM=xterm-ghostty`）は対象外。半ブロック文字での描画になっている
- viuer 0.11 は端末への問い合わせで判定するが、Ghostty は `a=q,t=t` の問い合わせに `OK` を返しつつ実際の `t=t`（一時ファイル）転送は `EINVAL: invalid data` で拒否する。このため 0.11 に上げると画像がまったく表示されなくなる
- `t=d`（データ直接送信）であれば Ghostty は `OK` を返し、96x96 のスプライトが潰れずに描画される（実機で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility for capturing raw terminal output from commands, with configurable terminal size and optional delayed input.
* **Bug Fixes**
  * Improved inline selection behavior by preserving existing terminal content when the selection interface closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->