### PR TITLE
feat: アローラのすがたなどのフォルムを辞書に追加

### DIFF
--- a/.github/scripts/fetch-pokemon-data.py
+++ b/.github/scripts/fetch-pokemon-data.py
@@ -93,7 +93,10 @@ def fetch_form_entry(base_ja: str, pokemon_url: str) -> Optional[Dict[str, str]]
     pokemon_data = fetch_json(pokemon_url)
     form_data = fetch_json(pokemon_data['forms'][0]['url'])
 
-    form_ja = find_localized_name(form_data.get('form_names', []), 'ja-hrkt')
+    # イワンコ（マイペース）のように form_names ではなく names 側にだけ
+    # 日本語名を持つフォルムがある
+    form_ja = find_localized_name(form_data.get('form_names', []), 'ja-hrkt') or \
+        find_localized_name(form_data.get('names', []), 'ja-hrkt')
     if not form_ja:
         return None
 

--- a/.github/scripts/fetch-pokemon-data.py
+++ b/.github/scripts/fetch-pokemon-data.py
@@ -280,7 +280,8 @@ def main():
         print(f'\n❌ Failed: {error_count} errors occurred during processing', file=sys.stderr)
         sys.exit(1)
 
-    print(f'\n✅ All {total} species and {len(variety_refs)} forms processed successfully', file=sys.stderr)
+    print(f'\n✅ All {total} species and {len(variety_refs)} forms processed successfully '
+          f'({len(entries)} entries)', file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/.github/scripts/fetch-pokemon-data.py
+++ b/.github/scripts/fetch-pokemon-data.py
@@ -11,13 +11,18 @@ from datetime import datetime, timezone
 from typing import List, Dict, Optional
 import urllib.request
 
+# 既定の python-urllib UA は PokéAPI に 403 で弾かれる
+USER_AGENT = 'poke-lookup-data-fetcher'
+
 def fetch_json(url: str, max_retries: int = 3) -> dict:
     """URLからJSONデータを取得（リトライ機能付き）"""
     last_error = None
 
+    request = urllib.request.Request(url, headers={'User-Agent': USER_AGENT})
+
     for attempt in range(max_retries):
         try:
-            with urllib.request.urlopen(url) as response:
+            with urllib.request.urlopen(request) as response:
                 return json.loads(response.read())
         except Exception as e:
             last_error = e
@@ -38,8 +43,9 @@ def get_name_pair(species_data: dict) -> Optional[Dict[str, str]]:
     en_name = None
 
     for name_entry in names:
-        lang = name_entry.get('language', {}).get('name')
-        if lang == 'ja-Hrkt':
+        # PokéAPI は言語コードの大文字小文字を変えることがある（ja-Hrkt → ja-hrkt）
+        lang = name_entry.get('language', {}).get('name', '').lower()
+        if lang == 'ja-hrkt':
             ja_name = name_entry.get('name')
         elif lang == 'en':
             en_name = name_entry.get('name')
@@ -90,6 +96,12 @@ def main():
             print(f'Error: Failed to process {species_ref["name"]}: {e}', file=sys.stderr)
             error_count += 1
             continue
+
+    # 名前の抽出に失敗しても error_count は増えないため、空のまま
+    # リリースされないようここで止める
+    if not entries:
+        print('\n❌ Failed: no entries were extracted', file=sys.stderr)
+        sys.exit(1)
 
     # エントリをソート
     entries.sort(key=lambda x: x['ja'])

--- a/.github/scripts/fetch-pokemon-data.py
+++ b/.github/scripts/fetch-pokemon-data.py
@@ -110,18 +110,19 @@ def fetch_form_entry(base_ja: str, pokemon_url: str) -> Optional[Dict[str, str]]
         'species_slug': pokemon_data['species']['name'],
     }
 
-def dedupe_en(form_entries: List[Dict[str, str]]) -> None:
+def dedupe_en(entries: List[Dict[str, str]]) -> None:
     """英名が衝突するフォルムをスラッグ由来の名前に置き換える
 
     英名は検索結果の出力値であり、スプライト取得のキーでもあるため一意である必要がある。
     メガイエッサン♂/♀ のように PokéAPI 側で同じ英名を持つフォルムが存在する。
+    種のエントリは書き換えず、フォルム側だけを変える。
     """
     duplicates = {
-        en for en, count in Counter(e['en'] for e in form_entries).items() if count > 1
+        en for en, count in Counter(e['en'] for e in entries).items() if count > 1
     }
 
-    for entry in form_entries:
-        if entry['en'] in duplicates:
+    for entry in entries:
+        if entry['en'] in duplicates and 'slug' in entry:
             entry['en'] = slug_to_en(entry['slug'])
 
 def form_tokens(entry: Dict[str, str]) -> List[str]:
@@ -136,20 +137,23 @@ def disambiguate_ja(entries: List[Dict[str, str]]) -> None:
     フォルムが日本語では同名になることがある。検索キーは日本語名なので
     （search.rs の HashMap）、同名のままでは選び分けられない。
     識別子はグループ内で差分になるトークンだけを使う（Orange / Combat など）。
+    種のエントリは書き換えず、フォルム側だけを変える。
     """
     groups = defaultdict(list)
     for entry in entries:
-        if 'slug' in entry:
-            groups[entry['ja']].append(entry)
+        groups[entry['ja']].append(entry)
 
     for group in groups.values():
         if len(group) < 2:
             continue
 
-        token_lists = [form_tokens(e) for e in group]
+        forms = [e for e in group if 'slug' in e]
+        token_lists = [form_tokens(e) for e in forms]
+        if not token_lists:
+            continue
         shared = set.intersection(*(set(t) for t in token_lists))
 
-        for entry, tokens in zip(group, token_lists):
+        for entry, tokens in zip(forms, token_lists):
             distinct = [t for t in tokens if t not in shared] or tokens
             label = ' '.join(t.capitalize() for t in distinct)
             # 「ロコン（アローラのすがた）」のように既に括弧付きなら中に足す
@@ -224,9 +228,9 @@ def main():
 
     print(f'Forms with names: {len(form_entries)} (skipped {skipped} without a Japanese name)', file=sys.stderr)
 
-    dedupe_en(form_entries)
     entries.extend(form_entries)
 
+    dedupe_en(entries)
     disambiguate_ja(entries)
     for entry in form_entries:
         del entry['slug']

--- a/.github/scripts/fetch-pokemon-data.py
+++ b/.github/scripts/fetch-pokemon-data.py
@@ -7,12 +7,17 @@ import json
 import sys
 import time
 import hashlib
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 import urllib.request
 
 # 既定の python-urllib UA は PokéAPI に 403 で弾かれる
 USER_AGENT = 'poke-lookup-data-fetcher'
+
+# フォルム取得は species の 3 倍近いリクエストになるため並列化する
+FORM_WORKERS = 8
 
 def fetch_json(url: str, max_retries: int = 3) -> dict:
     """URLからJSONデータを取得（リトライ機能付き）"""
@@ -34,25 +39,121 @@ def fetch_json(url: str, max_retries: int = 3) -> dict:
     # 全てのリトライが失敗した場合
     raise last_error
 
+def find_localized_name(names: List[dict], lang: str) -> Optional[str]:
+    """名前リストから指定言語の名前を取り出す
+
+    PokéAPI は言語コードの大文字小文字を変えることがある（ja-Hrkt → ja-hrkt）。
+    """
+    for name_entry in names:
+        if name_entry.get('language', {}).get('name', '').lower() == lang:
+            return name_entry.get('name')
+    return None
+
 def get_name_pair(species_data: dict) -> Optional[Dict[str, str]]:
     """種データから日本語名と英名のペアを抽出"""
     names = species_data.get('names', [])
     pokemon_id = species_data.get('id')
 
-    ja_name = None
-    en_name = None
-
-    for name_entry in names:
-        # PokéAPI は言語コードの大文字小文字を変えることがある（ja-Hrkt → ja-hrkt）
-        lang = name_entry.get('language', {}).get('name', '').lower()
-        if lang == 'ja-hrkt':
-            ja_name = name_entry.get('name')
-        elif lang == 'en':
-            en_name = name_entry.get('name')
+    ja_name = find_localized_name(names, 'ja-hrkt')
+    en_name = find_localized_name(names, 'en')
 
     if ja_name and en_name and pokemon_id:
         return {'ja': ja_name, 'en': en_name, 'id': pokemon_id}
     return None
+
+def get_variety_refs(species_data: dict, base_ja: str) -> List[Tuple[str, str]]:
+    """種データから非デフォルトの個体（フォルム）URLと種の日本語名を返す"""
+    return [
+        (base_ja, v['pokemon']['url'])
+        for v in species_data.get('varieties', [])
+        if not v.get('is_default')
+    ]
+
+def compose_ja(base_ja: str, form_ja: str) -> str:
+    """種名とフォルム名から表示用の日本語名を組み立てる
+
+    PokéAPI の form_names には 2 種類あり、メガフシギバナのように単体で
+    完結するものと、アローラのすがたのようにフォルムの呼称だけのものがある。
+    後者は種名が含まれないので合成する。
+    """
+    if base_ja in form_ja:
+        return form_ja
+    return f'{base_ja}（{form_ja}）'
+
+def slug_to_en(slug: str) -> str:
+    """英名を持たないフォルム（コライドン/ミライドンの各ビルド）用のフォールバック"""
+    return ' '.join(part.capitalize() for part in slug.split('-'))
+
+def fetch_form_entry(base_ja: str, pokemon_url: str) -> Optional[Dict[str, str]]:
+    """個体URLからフォルムのエントリを作る
+
+    pokemon と pokemon-form は id 体系が別なので、pokemon 経由で form を辿る。
+    日本語名を持たないフォルム（トーテム個体など）は None を返す。
+    """
+    pokemon_data = fetch_json(pokemon_url)
+    form_data = fetch_json(pokemon_data['forms'][0]['url'])
+
+    form_ja = find_localized_name(form_data.get('form_names', []), 'ja-hrkt')
+    if not form_ja:
+        return None
+
+    form_en = find_localized_name(form_data.get('names', []), 'en')
+
+    return {
+        'ja': compose_ja(base_ja, form_ja),
+        'en': form_en or slug_to_en(pokemon_data['name']),
+        'id': pokemon_data['id'],
+        'slug': pokemon_data['name'],
+        'species_slug': pokemon_data['species']['name'],
+    }
+
+def dedupe_en(form_entries: List[Dict[str, str]]) -> None:
+    """英名が衝突するフォルムをスラッグ由来の名前に置き換える
+
+    英名は検索結果の出力値であり、スプライト取得のキーでもあるため一意である必要がある。
+    メガイエッサン♂/♀ のように PokéAPI 側で同じ英名を持つフォルムが存在する。
+    """
+    duplicates = {
+        en for en, count in Counter(e['en'] for e in form_entries).items() if count > 1
+    }
+
+    for entry in form_entries:
+        if entry['en'] in duplicates:
+            entry['en'] = slug_to_en(entry['slug'])
+
+def form_tokens(entry: Dict[str, str]) -> List[str]:
+    """個体スラッグから種名を除いた、フォルムを表すトークン列"""
+    species_tokens = set(entry['species_slug'].split('-'))
+    return [t for t in entry['slug'].split('-') if t not in species_tokens]
+
+def disambiguate_ja(entries: List[Dict[str, str]]) -> None:
+    """日本語名が衝突するフォルムに英語の識別子を付けて一意にする
+
+    メテノのりゅうせいのすがた（色違い 7 件）のように、英語では区別される
+    フォルムが日本語では同名になることがある。検索キーは日本語名なので
+    （search.rs の HashMap）、同名のままでは選び分けられない。
+    識別子はグループ内で差分になるトークンだけを使う（Orange / Combat など）。
+    """
+    groups = defaultdict(list)
+    for entry in entries:
+        if 'slug' in entry:
+            groups[entry['ja']].append(entry)
+
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+
+        token_lists = [form_tokens(e) for e in group]
+        shared = set.intersection(*(set(t) for t in token_lists))
+
+        for entry, tokens in zip(group, token_lists):
+            distinct = [t for t in tokens if t not in shared] or tokens
+            label = ' '.join(t.capitalize() for t in distinct)
+            # 「ロコン（アローラのすがた）」のように既に括弧付きなら中に足す
+            if entry['ja'].endswith('）'):
+                entry['ja'] = f'{entry["ja"][:-1]}・{label}）'
+            else:
+                entry['ja'] = f'{entry["ja"]}（{label}）'
 
 def main():
     output_file = sys.argv[1] if len(sys.argv) > 1 else 'names.json'
@@ -71,6 +172,7 @@ def main():
     species_list = fetch_json(f'{api_base}/pokemon-species?limit={total_count}')
 
     entries = []
+    variety_refs = []
     error_count = 0
     total = len(species_list['results'])
 
@@ -92,16 +194,54 @@ def main():
             name_pair = get_name_pair(species_data)
             if name_pair:
                 entries.append(name_pair)
+                variety_refs.extend(get_variety_refs(species_data, name_pair['ja']))
         except Exception as e:
             print(f'Error: Failed to process {species_ref["name"]}: {e}', file=sys.stderr)
             error_count += 1
             continue
+
+    # フォルム（アローラのすがた・メガシンカなど）は species ではなく
+    # pokemon-form 側にしかないので、非デフォルト個体を辿って追加する
+    print(f'\nProcessing {len(variety_refs)} forms...', file=sys.stderr)
+
+    def process_variety(ref):
+        base_ja, pokemon_url = ref
+        try:
+            return fetch_form_entry(base_ja, pokemon_url)
+        except Exception as e:
+            print(f'Error: Failed to process form {pokemon_url}: {e}', file=sys.stderr)
+            return e
+
+    with ThreadPoolExecutor(FORM_WORKERS) as executor:
+        results = list(executor.map(process_variety, variety_refs))
+
+    error_count += sum(1 for r in results if isinstance(r, Exception))
+    form_entries = [r for r in results if isinstance(r, dict)]
+    skipped = sum(1 for r in results if r is None)
+
+    print(f'Forms with names: {len(form_entries)} (skipped {skipped} without a Japanese name)', file=sys.stderr)
+
+    dedupe_en(form_entries)
+    entries.extend(form_entries)
+
+    disambiguate_ja(entries)
+    for entry in form_entries:
+        del entry['slug']
+        del entry['species_slug']
 
     # 名前の抽出に失敗しても error_count は増えないため、空のまま
     # リリースされないようここで止める
     if not entries:
         print('\n❌ Failed: no entries were extracted', file=sys.stderr)
         sys.exit(1)
+
+    # 日本語名は検索キー、英名は検索結果の出力値かつスプライト取得のキーなので
+    # どちらも一意でなければならない（search.rs / sprite.rs の HashMap）
+    for field in ('ja', 'en'):
+        duplicates = [v for v, count in Counter(e[field] for e in entries).items() if count > 1]
+        if duplicates:
+            print(f'\n❌ Failed: duplicate {field} names: {duplicates}', file=sys.stderr)
+            sys.exit(1)
 
     # エントリをソート
     entries.sort(key=lambda x: x['ja'])
@@ -133,7 +273,7 @@ def main():
         print(f'\n❌ Failed: {error_count} errors occurred during processing', file=sys.stderr)
         sys.exit(1)
 
-    print(f'\n✅ All {total} species processed successfully', file=sys.stderr)
+    print(f'\n✅ All {total} species and {len(variety_refs)} forms processed successfully', file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/.github/scripts/fetch-pokemon-data.py
+++ b/.github/scripts/fetch-pokemon-data.py
@@ -236,12 +236,6 @@ def main():
         del entry['slug']
         del entry['species_slug']
 
-    # 名前の抽出に失敗しても error_count は増えないため、空のまま
-    # リリースされないようここで止める
-    if not entries:
-        print('\n❌ Failed: no entries were extracted', file=sys.stderr)
-        sys.exit(1)
-
     # 日本語名は検索キー、英名は検索結果の出力値かつスプライト取得のキーなので
     # どちらも一意でなければならない（search.rs / sprite.rs の HashMap）
     for field in ('ja', 'en'):

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-data:
     runs-on: ubuntu-latest
-    timeout-minutes: 10  # タイムアウトを10分に設定（API呼び出しのため）
+    timeout-minutes: 20  # タイムアウトを20分に設定（species に加えフォルムも取得するため）
     permissions:
       contents: write
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cargo uninstall poke-lookup
 ## データ更新について
 
 - GitHub Actions により毎月1日に自動更新
-- PokéAPI から全ポケモン種（1025+）のデータを取得
+- PokéAPI から全ポケモン種（1025+）と、そのフォルム（アローラのすがた・メガシンカなど）のデータを取得
 - GitHub Releases で配布（SHA256 チェックサム付き）
 
 ## トラブルシューティング

--- a/src/romaji.rs
+++ b/src/romaji.rs
@@ -174,8 +174,17 @@ fn is_vowel(c: char) -> bool {
     matches!(c, 'a' | 'i' | 'u' | 'e' | 'o')
 }
 
+/// ひらがなをカタカナへ寄せる。変換表はカタカナのみなので、
+/// フォルム名（あかつきのつばさ 等）を引けるようにするための前処理
+fn to_katakana(c: char) -> char {
+    match c {
+        'ぁ'..='ゖ' => char::from_u32(c as u32 + 0x60).unwrap_or(c),
+        _ => c,
+    }
+}
+
 fn to_romaji(katakana: &str, style: Style) -> String {
-    let chars: Vec<char> = katakana.chars().collect();
+    let chars: Vec<char> = katakana.chars().map(to_katakana).collect();
     let mut out = String::new();
     let mut i = 0;
     // 直前に ッ があったか。子音を重ねる対象は次の音なので持ち越す
@@ -273,6 +282,16 @@ mod tests {
     fn test_unknown_char_passes_through() {
         // 変換表にない文字は落とさずそのまま通す
         assert_eq!(variants("ポリゴン2"), vec!["porigon2"]);
+    }
+
+    #[test]
+    fn test_hiragana_is_normalized_to_katakana() {
+        // フォルム名はひらがな混じり（あかつきのつばさ 等）
+        assert_eq!(variants("すがた"), vec!["sugata"]);
+        assert_eq!(
+            variants("ロコン（アローラのすがた）"),
+            vec!["rokon（arooranosugata）"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

辞書にアローラ／ガラル／ヒスイ／パルデア／メガ／キョダイマックスなどの「すがた違い」が1件も入っていなかった。PokéAPI では種（species）とフォルム（form）が別リソースで、生成スクリプトが `/pokemon-species` しか見ていなかったため。

あわせて、PokéAPI 側の変更で**現行の生成スクリプトが日本語名を1件も抽出できなくなっている**（言語コードが `ja-Hrkt` → `ja-hrkt`）不具合も見つかったので修正した。エラーカウントは増えないため、次回の定期実行では空の names.json がそのままリリースされる状態だった。直近リリース data-9（2026-01-01）は1025件で無事。

## 変更

- `fix`: 言語コードを大文字小文字無視で比較。User-Agent 付与（既定の urllib UA は 403）。抽出0件時に exit 1 するガード
- `feat`: 非デフォルト個体を辿って `pokemon-form` から日本語名を取得し辞書に追加
  - ja はフォルム名が種名を含めばそのまま（`メガフシギバナ`）、含まなければ合成（`ロコン（アローラのすがた）`）
  - ja が衝突する13グループは、グループ内で差分になる英語トークンを付けて一意化（`メテノ（りゅうせいのすがた・Orange）`）
  - en の欠落・衝突はスラッグ由来の名前で補う
  - id は個体 id なのでスプライトは既存の URL 組み立てのまま動く
  - 日本語名を持たないフォルム（トーテム個体など16件）は除外
- `feat`: ローマ字変換でひらがなをカタカナへ正規化（フォルム名の164件がひらがな混じりでローマ字絞り込みが効かないため）
- `ci`: リクエストが約1000→1700件に増えるためワークフローのタイムアウトを 10→20分

## 検証

実データでフル生成し、1025種 + フォルム326件中310件 = **1335件**、日本語名・英名とも一意、エラー0を確認。生成した辞書でCLIも確認：

```
$ poke-lookup --dict names.json "ロコン（アローラのすがた）"
Alolan Vulpix
$ poke-lookup --dict names.json "メガフシギバナ"
Mega Venusaur
```

`cargo test` 50件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Pokémon data retrieval to support all species forms (Alolan forms, Mega Evolutions, etc.).

* **Bug Fixes**
  * Improved hiragana character handling in romaji conversion.

* **Documentation**
  * Updated data documentation for comprehensive Pokémon form coverage.

* **Tests**
  * Added hiragana normalization tests.

* **Chores**
  * Extended data-update workflow timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->