### PR TITLE
fix: スプライト確認画面のキー入力を KeyEventKind::Press に限定する

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -6,7 +6,7 @@ use crate::sprite::SpriteService;
 use anyhow::{Context, Result};
 #[cfg(feature = "sprites")]
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEvent},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 use skim::prelude::*;
@@ -279,7 +279,14 @@ impl InteractiveSelector {
         enable_raw_mode()?;
 
         let result = loop {
-            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+            // Press のみを扱う。Repeat / Release にマッチすると
+            // 押しっぱなしや離した際に鳴らし直し・確定が誤発火する（issue #18）
+            if let Event::Key(KeyEvent {
+                code,
+                kind: KeyEventKind::Press,
+                ..
+            }) = event::read()?
+            {
                 match code {
                     KeyCode::Enter => {
                         disable_raw_mode()?;


### PR DESCRIPTION
## 概要

スプライト確認画面のキーループ（`src/interactive.rs`）が `Event::Key(KeyEvent { code, .. })` で受けており `KeyEventKind` を見ていなかった。ループ全体を `KeyEventKind::Press` に限定する。

## この修正が実際に効く挙動

crossterm のソースを確認した結果、実効性は**プラットフォーム依存**。

- **Windows**（`crossterm-0.27 windows/parse.rs:285-291`）: コンソールがキーの押下(key_down)と離上(key_up)の両方をイベントとして返し、それぞれ `Press` / `Release` になる。修正前は `kind` を無視するため、`Char(' ')` が Press と Release の両方にマッチし、**Space を1回押すと鳴き声が2回鳴る**。`Press` 限定でこれを1回に直す。← 本修正の主目的
- **Unix 標準ターミナル**（`unix/parse.rs`）: キーボード拡張（REPORT_EVENT_TYPES）を有効化しない限り Repeat / Release は報告されず、Space は `Press` として届く。よって**この修正は挙動を変えない**（no-op / 予防的）。

## スコープ外（この PR では直さない）

- OS のキーオートリピートによる「押しっぱなしで Press が連発 → 繰り返し鳴る」挙動。これは本物の `Press` イベントの連続なので `Press` 限定では止まらない。別課題。
- スプライトが `-s` を無視して常に表示される件（#20）。

## 変更内容

- `Event::Key(KeyEvent { code, kind: KeyEventKind::Press, .. })` でマッチするよう修正
- `KeyEventKind` を import に追加
- Enter / Esc も同じ Press 限定に揃える

## 検証

- `cargo build` / `cargo build --features sprites,cries` 成功
- `cargo test` 50 件パス
- 実キー操作の Windows 二重発火解消は、Windows 実機での確認が必要（macOS 環境では再現しないため未確認）

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)