### PR TITLE
種族値・タイプ表示の見た目を整える

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -363,14 +363,15 @@ fn format_stats(stats: &[StatEntry]) -> String {
     out
 }
 
-/// `ラベル 値 ████░░░░` 形式の1行を作る。label は表示幅8桁に揃え済み
+/// `ラベル  値 ████░░░░` 形式の1行を作る。label は表示幅8桁に揃え済みで、
+/// 値との間には固定スペースを2つ入れる（3桁の値でもラベルと密着させないため）
 #[cfg(feature = "sprites")]
 fn format_stat_gauge(label: &str, value: u16) -> String {
     // ここで STAT_MAX にクランプするため filled は必ず GAUGE_WIDTH 以下。
     // この .min(STAT_MAX) を外すと下の GAUGE_WIDTH - filled がアンダーフローする
     let filled = value.min(STAT_MAX) as usize * GAUGE_WIDTH / STAT_MAX as usize;
     format!(
-        "{}{:>3} {}{}{}{}{}",
+        "{}  {:>3} {}{}{}{}{}",
         label,
         value,
         GAUGE_FILL,
@@ -396,9 +397,9 @@ mod tests {
                 .replace(SGR_RESET, "")
         };
         // 0 は空、上限(150)以上は満杯、中間は比例（35/150*20 = 4 マス）
-        assert_eq!(bare("HP      ", 0), "HP        0 ░░░░░░░░░░░░░░░░░░░░");
-        assert_eq!(bare("すばやさ", 255), "すばやさ255 ████████████████████");
-        assert_eq!(bare("HP      ", 35), "HP       35 ████░░░░░░░░░░░░░░░░");
+        assert_eq!(bare("HP      ", 0), "HP          0 ░░░░░░░░░░░░░░░░░░░░");
+        assert_eq!(bare("すばやさ", 255), "すばやさ  255 ████████████████████");
+        assert_eq!(bare("HP      ", 35), "HP         35 ████░░░░░░░░░░░░░░░░");
         assert!(format_stat_gauge("HP      ", 35).contains(GAUGE_FILL));
     }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -359,7 +359,7 @@ fn format_stats(stats: &[StatEntry]) -> String {
         out.push_str(&format_stat_gauge(stat.label, stat.value));
         out.push('\n');
     }
-    out.push_str(&format!("合計    {}\n", total));
+    out.push_str(&format!("ごうけい  {:>3}\n", total));
     out
 }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -343,7 +343,7 @@ fn format_types(types: &[PokemonType]) -> String {
         .iter()
         .map(|t| format!("{} {} {}", t.color, t.ja, SGR_RESET))
         .collect();
-    format!("\nタイプ: {}\n", chips.join(" "))
+    format!("\n{}\n", chips.join(" "))
 }
 
 /// 種族値ゲージ（各行）と合計。空なら空文字


### PR DESCRIPTION
## 概要
スプライト下に出るタイプ・種族値表示の見た目を3点調整。

## 変更内容
1. **タイプラベル削除** — 色チップ（ほのお/みず等）だけで種別が分かるため「タイプ:」ラベルを削除
2. **合計→ごうけい** — 他ラベル（こうげき/ぼうぎょ等）がひらがなのため統一。値も右詰めで整列
3. **ゲージ間隔** — ラベルと値の間を1→2スペースに（`ぼうぎょ160` のように3桁で密着するのを解消）

各項目を1コミットに分けています。

## テスト
- `cargo test`（default 50件）パス
- `cargo test --features sprites info::tests::test_format_stat_gauge` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved display formatting for type information and stat totals.
  * Standardized spacing and alignment in stat gauge rows.

* **Bug Fixes**
  * Updated gauge output to present values more clearly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->