### PR TITLE
build: デフォルトフィーチャーに sprites と cries を含める

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossterm = { version = "0.27", optional = true }
 rodio = { version = "0.22", optional = true }
 
 [features]
-default = []
+default = ["sprites", "cries"]
 sprites = ["viuer", "image", "crossterm"]
 cries = ["rodio"]
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - Rust 1.70以上
 - Git（クローン用）
 - インターネット接続（初回セットアップ時のデータダウンロード用）
+- Linux の場合のみ、鳴き声機能が依存する ALSA の開発ヘッダ（`libasound2-dev`）
 
 ### インストール手順
 
@@ -35,29 +36,28 @@ cd poke-lookup
 cargo install --path .
 ```
 
-これにより `poke-lookup` コマンドがどこからでも実行可能になります。
-
-### スプライト機能付きインストール
-
-ターミナル内でポケモンのスプライト画像を表示したい場合：
-
-```bash
-cargo install --path . --features sprites
-```
+これにより `poke-lookup` コマンドがどこからでも実行可能になります。スプライト表示と鳴き声再生はデフォルトで有効なので、追加の指定は不要です。
 
 https://github.com/user-attachments/assets/7f80ef19-2117-4c19-b8a8-96bdf55d6ee3
+
+### 最小構成でのインストール
+
+スプライトと鳴き声を無効にし、依存を減らした最小構成でビルドしたい場合：
+
+```bash
+cargo install --path . --no-default-features
+```
+
+個別に有効化したい場合は `--features sprites` / `--features cries` を組み合わせてください。
 
 ### 手動ビルド（開発用）
 
 ```bash
-# 基本機能のみ
+# 全機能付き（デフォルト）
 cargo build --release
 
-# スプライト機能付き
-cargo build --release --features sprites
-
-# 鳴き声機能付き
-cargo build --release --features cries
+# 最小構成（スプライト・鳴き声なし）
+cargo build --release --no-default-features
 ```
 
 ### 開発環境のセットアップ
@@ -114,9 +114,9 @@ $ poke-lookup
 
 なお**引数に渡すローマ字は対象外**です。`poke-lookup fushigidane` は候補なしになります。ローマ字を使う場合は引数なしで起動してください。
 
-### スプライト表示（オプション機能）
+### スプライト表示
 
-スプライト機能付きでビルドした場合、ポケモンの画像をターミナル内に表示できます：
+ポケモンの画像をターミナル内に表示できます：
 
 ```bash
 # 英名と一緒にスプライトを表示
@@ -140,11 +140,11 @@ $ poke-lookup フシギ -s
 - WezTerm
 - その他の画像表示対応ターミナル
 
-**注意:** スプライト機能は `--features sprites` でビルドした場合のみ利用可能です。
+**注意:** スプライト機能はデフォルトで有効です。最小構成（`--no-default-features`）でビルドした場合のみ無効になります。
 
-### 鳴き声再生（オプション機能）
+### 鳴き声再生
 
-鳴き声機能付きでビルドした場合、選択したポケモンの鳴き声を再生できます：
+選択したポケモンの鳴き声を再生できます：
 
 ```bash
 # 英名を出力して鳴き声を再生
@@ -164,7 +164,7 @@ $ poke-lookup フシギ -c
 
 取得は3秒でタイムアウトし、音声デバイスが無い環境と同じく黙ってスキップされます。いずれの場合も標準出力は変わらないので、パイプライン中で使っても影響ありません。
 
-**注意:** 鳴き声機能は `--features cries` でビルドした場合のみ利用可能です（`cargo install --path . --features cries`）。Linux では ALSA の開発ヘッダ（`libasound2-dev`）が必要です。
+**注意:** 鳴き声機能はデフォルトで有効です。最小構成（`--no-default-features`）でビルドした場合のみ無効になります。Linux では ALSA の開発ヘッダ（`libasound2-dev`）が必要です。
 
 ### データ更新
 
@@ -255,10 +255,10 @@ poke-lookup update
    poke-lookup update
    ```
 
-4. **フィーチャー無効でビルドした場合**
+4. **最小構成でビルドした場合**
    ```bash
-   # スプライト機能付きで再ビルド
-   cargo install --path . --features sprites --force
+   # デフォルト（全機能付き）で再ビルド
+   cargo install --path . --force
    ```
 
 ## 開発
@@ -266,11 +266,11 @@ poke-lookup update
 ### テスト実行
 
 ```bash
-# 基本機能のテスト
+# 全機能のテスト（デフォルト）
 cargo test
 
-# 全機能のテスト（スプライト機能含む）
-cargo test --all-features
+# 最小構成のテスト
+cargo test --no-default-features
 ```
 
 ### データ取得スクリプト（CI/CD 用）

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 - 🎯 完全一致で即座に結果を返す
 - 📝 部分一致時はインタラクティブ選択（skim 使用）
 - ⌨️ インタラクティブ選択ではローマ字入力でも絞り込み可能
-- 🖼️ ターミナル内スプライト表示（オプション機能）
-- 🔊 鳴き声再生（オプション機能）
+- 🖼️ ターミナル内スプライト表示（デフォルトで有効）
+- 🔊 鳴き声再生（デフォルトで有効）
 - 🔄 月次自動データ更新（GitHub Actions）
 - 🔒 SHA256 によるデータ整合性チェック
 - 🌐 PokéAPI 準拠のデータ
@@ -48,7 +48,7 @@ https://github.com/user-attachments/assets/7f80ef19-2117-4c19-b8a8-96bdf55d6ee3
 cargo install --path . --no-default-features
 ```
 
-個別に有効化したい場合は `--features sprites` / `--features cries` を組み合わせてください。
+どちらか一方だけにしたい場合は `--no-default-features --features sprites` / `--no-default-features --features cries` を指定してください。
 
 ### 手動ビルド（開発用）
 


### PR DESCRIPTION
## 背景 / 動機

`--play-cry` (`-c`) を付けても鳴き声が鳴らない、という報告から調査した。原因は環境やコードの不具合ではなく **フィーチャー設計** だった。

- `Cargo.toml` は `default = []` で、`sprites` / `cries` は両方ともデフォルト無効
- 一方 README 冒頭の推奨インストール `cargo install --path .` はフィーチャー指定なし
- 結果、推奨手順どおり入れると **advertise している機能が両方入らないバイナリ** が出来る
- しかも `-c` / `-s` フラグはフィーチャー非依存で定義されているため `--help` には出る。指定してもエラーにならず、`-c` は**黙って無音**（exit 0）で終わる

実機で確認: インストール済みバイナリには rodio/symphonia シンボルが 0（cries 無効ビルド）。`--features cries` でビルドし直した版は正常に約1秒鳴った。

## 変更内容

- `default = ["sprites", "cries"]` に反転。普通に `cargo install --path .` すれば音もスプライトも動く
- 依存を避けたい場合は `--no-default-features` で明示的に opt-out する形へ
- README を追従（推奨インストールの記述、opt-in→opt-out への反転、Linux `libasound2-dev` の明記、各機能の「オプション機能」表記除去、再ビルド/テスト手順の更新）

## 影響

- Linux では default ビルドが ALSA 開発ヘッダに依存するようになる。CI は default ビルドの前に `libasound2-dev` を導入済みのため影響なし（ci.yml）
- テスト 79 件 green、fmt / clippy 通過

## 残課題（別対応）

`--no-default-features` でビルドした場合に限り、`-c` サイレント無音は依然残る。スプライトは `main.rs:232` で「`--features sprites` でビルドしてください」と案内するのに対し、cries には同等のフォールバックが無い。別 issue として切り出し予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sprites and Pokémon cries are now enabled by default.

* **Documentation**
  * Updated installation instructions, including the required ALSA development headers on Linux.
  * Added guidance for minimal, selective, and manual builds.
  * Documented how to disable default features and updated troubleshooting and testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->