### PR TITLE
fix: スプライト表示を -s / --show-sprite フラグでゲートする

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -104,8 +104,6 @@ impl InteractiveSelector {
     pub fn new(search_service: SearchService) -> Self {
         Self {
             search_service,
-            // スプライト表示は show_sprite(true)（= -s）で初めて有効化する。
-            // cry_service と対称にし、フラグなしでは対話選択中も画像を出さない（issue #20）
             #[cfg(feature = "sprites")]
             sprite_service: None,
             #[cfg(feature = "sprites")]
@@ -115,8 +113,7 @@ impl InteractiveSelector {
         }
     }
 
-    /// 有効時のみ SpriteService / PokemonInfoService を初期化する。
-    /// info は対話選択中のスプライト表示でしか使わないため一緒にゲートする
+    /// info は対話選択中のスプライト表示でしか使わないため sprite と同時にゲートする
     #[cfg_attr(not(feature = "sprites"), allow(unused_mut, unused_variables))]
     pub fn show_sprite(mut self, enabled: bool) -> Self {
         #[cfg(feature = "sprites")]

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -102,20 +102,31 @@ pub struct InteractiveSelector {
 impl InteractiveSelector {
     /// 検索サービスからセレクターを作成
     pub fn new(search_service: SearchService) -> Self {
-        #[cfg(feature = "sprites")]
-        let sprite_service = SpriteService::new().ok();
-        #[cfg(feature = "sprites")]
-        let info_service = PokemonInfoService::new().ok();
-
         Self {
             search_service,
+            // スプライト表示は show_sprite(true)（= -s）で初めて有効化する。
+            // cry_service と対称にし、フラグなしでは対話選択中も画像を出さない（issue #20）
             #[cfg(feature = "sprites")]
-            sprite_service,
+            sprite_service: None,
             #[cfg(feature = "sprites")]
-            info_service,
+            info_service: None,
             #[cfg(feature = "cries")]
             cry_service: None,
         }
+    }
+
+    /// 有効時のみ SpriteService / PokemonInfoService を初期化する。
+    /// info は対話選択中のスプライト表示でしか使わないため一緒にゲートする
+    #[cfg_attr(not(feature = "sprites"), allow(unused_mut, unused_variables))]
+    pub fn show_sprite(mut self, enabled: bool) -> Self {
+        #[cfg(feature = "sprites")]
+        if enabled {
+            // 初期化失敗（画像表示不可の端末など）は None のまま握りつぶす。
+            // -s でも表示できないだけで、選択自体は続行させる
+            self.sprite_service = SpriteService::new().ok();
+            self.info_service = PokemonInfoService::new().ok();
+        }
+        self
     }
 
     /// 有効時のみ CryService を初期化する（辞書の再読み込みを避けるため）

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,9 @@ fn search_pokemon(
     };
 
     // インタラクティブセレクターを作成
-    let selector = InteractiveSelector::new(search_service.clone()).play_cry(play_cry);
+    let selector = InteractiveSelector::new(search_service.clone())
+        .show_sprite(show_sprite)
+        .play_cry(play_cry);
 
     // 検索実行
     match selector.select_interactive(japanese_name)? {
@@ -162,7 +164,9 @@ fn search_interactive_all(
     };
 
     // インタラクティブセレクターを作成
-    let selector = InteractiveSelector::new(search_service.clone()).play_cry(play_cry);
+    let selector = InteractiveSelector::new(search_service.clone())
+        .show_sprite(show_sprite)
+        .play_cry(play_cry);
 
     // 全候補から選択
     match selector.select_from_all()? {


### PR DESCRIPTION
## 概要

対話選択中のスプライト表示が `-s` / `--show-sprite` フラグを無視して常に表示される問題（issue #20）を修正する。

## 原因

スプライト表示には2経路ある。

- **経路1（対話選択中）** `run_skim_selection` 内の `show_sprite_with_navigation` は `sprite_service` が `Some` かどうかだけでゲートされていた。その `sprite_service` は `new()` でフラグに関係なく無条件に初期化されるため、`--features sprites` でビルドされていれば `-s` の有無に関わらず画像が出ていた。
- **経路2（選択確定後）** `main.rs` の `if show_sprite { … }` は `-s` でゲート済み。完全一致（skim を通らない）時は唯一の表示経路。

一方 `cry_service` は `new()` で `None` から始まり `play_cry(true)`（= `-c`）で初めて有効化される。この非対称が挙動の不一致の原因。

## 対応

`cry_service` と対称になるよう、

- `new()` では `sprite_service` / `info_service` を `None` 初期化
- `show_sprite(bool)` ビルダを追加し、`-s` のときだけ両サービスを初期化

`info_service` は対話選択中の表示でしか使わないため一緒にゲートする。`main.rs` の2箇所の selector 構築に `.show_sprite(show_sprite)` を追加。

## 検証

- `cargo build` 4パターン（default / no-default / sprites単体 / cries単体）成功
- `cargo clippy --all-targets` 警告なし
- `cargo test` 79 passed
- `cargo fmt --check` 差分なし

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to enable or disable Pokémon sprite display in interactive selection.
  - Sprite and Pokémon information services now initialize only when sprite display is enabled.

- **Bug Fixes**
  - Interactive selection can continue even if sprite-related services fail to initialize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->