### PR TITLE
feat: 候補リストの半ページ送りを Ctrl+D / Ctrl+U に割り当て

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ poke-lookup update
 
 操作方法：
 - `↑` / `↓` または `Ctrl+P` / `Ctrl+N`: 上下移動
+- `Ctrl+D` / `Ctrl+U`: 半ページ送り／戻し
 - `Enter`: 選択確定
 - `Ctrl+C` / `Esc`: キャンセル
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -232,7 +232,16 @@ impl InteractiveSelector {
             .preview_window(Some("down:3:wrap"))
             .query(Some(initial_query))
             .prompt(Some("ポケモンを選択: "))
-            .bind(vec!["ctrl-n:down", "ctrl-p:up", "ctrl-j:down", "ctrl-k:up"])
+            // ctrl-d / ctrl-u は skim 既定の delete-char-EOF / 行削除を潰して
+            // 半ページ送りに充てる。矢印や PageUp/PageDown を使わずに送りたいため
+            .bind(vec![
+                "ctrl-n:down",
+                "ctrl-p:up",
+                "ctrl-j:down",
+                "ctrl-k:up",
+                "ctrl-d:half-page-down",
+                "ctrl-u:half-page-up",
+            ])
             .build()
             .context("Failed to build skim options")?;
 


### PR DESCRIPTION
## 背景

候補リストのページ送りは skim 既定の `PageUp` / `PageDown` しか無く、矢印キーや PageUp/PageDown を使わずに送りたいという要望があった。

## 変更

- `src/interactive.rs` の `bind` に `ctrl-d:half-page-down` / `ctrl-u:half-page-up` を追加
- README の操作方法に1行追記

既存の `Ctrl+P`/`Ctrl+N`（1行移動）と向きが揃うように、`Ctrl+U` が上方向。

## 動作確認

`scripts/debug/pty-capture.py` で pty 上のカーソル位置を確認（リスト表示 7 行 → 半ページ = 3 件）。

| 送ったキー | カーソル位置 |
|---|---|
| なし | 0 |
| `Ctrl+U` | 3 |
| `Ctrl+U` ×2 | 6 |
| `Ctrl+U` ×2 → `Ctrl+D` | 3 |
| `Ctrl+D`（先頭で） | 0（先頭で止まる） |

`cargo test` 86 件通過、fmt/clippy も通過。

## トレードオフ

skim 既定の `Ctrl+U`（クエリの行削除）と `Ctrl+D`（EOF 削除）は上書きされる。行削除は `Ctrl+W`（単語削除）で代替可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Ctrl+D` and `Ctrl+U` shortcuts for moving forward or backward by half a page in interactive selection.
  * Existing single-line navigation shortcuts remain available.

* **Documentation**
  * Updated the troubleshooting guide with the new half-page navigation shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->